### PR TITLE
The 'preprocessor' option for esbuild-svelte is deprecated, please us…

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -8,7 +8,7 @@ const svelteConfig = {
         css: false  //use `css:true` to inline CSS in `bundle.js`
     },
     
-    preprocessor:[
+    preprocess:[
         // Place here any Svelte preprocessors
     ]
     


### PR DESCRIPTION
…e 'preprocess' instead

The 'preprocessor' option for esbuild-svelte is deprecated, please use 'preprocess' instead